### PR TITLE
support transformers 5.0

### DIFF
--- a/FlashVSR/diffsynth/extensions/ImageQualityMetric/open_clip/hf_model.py
+++ b/FlashVSR/diffsynth/extensions/ImageQualityMetric/open_clip/hf_model.py
@@ -11,7 +11,8 @@ from torch import TensorType
 
 try:
     import transformers
-    from transformers import AutoModel, AutoTokenizer, AutoConfig, PretrainedConfig
+    from transformers import AutoModel, AutoTokenizer, AutoConfig
+    from transformers.configuration_utils import PretrainedConfig
     from transformers.modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling, \
         BaseModelOutputWithPoolingAndCrossAttentions
 except ImportError as e:

--- a/FlashVSR/diffsynth/models/kolors_text_encoder.py
+++ b/FlashVSR/diffsynth/models/kolors_text_encoder.py
@@ -32,7 +32,7 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
 from transformers.generation.logits_process import LogitsProcessor
 from transformers.generation.utils import LogitsProcessorList, StoppingCriteriaList, GenerationConfig, ModelOutput
-from transformers import PretrainedConfig
+from transformers.configuration_utils import PretrainedConfig
 from torch.nn.parameter import Parameter
 import bz2
 import torch

--- a/FlashVSR/diffsynth/models/stepvideo_text_encoder.py
+++ b/FlashVSR/diffsynth/models/stepvideo_text_encoder.py
@@ -18,7 +18,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from .stepvideo_dit import RMSNorm
 from safetensors.torch import load_file
-from transformers.modeling_utils import PretrainedConfig, PreTrainedModel
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_utils import PreTrainedModel
 from einops import rearrange
 import json
 from typing import List


### PR DESCRIPTION
transformers 库在 5.0 版本中进行了重大的 API 清理，导致 PretrainedConfig 类被移动，根据新的类位置修改import